### PR TITLE
readme update, license added, travis fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # Ignored Output
 /output/
+__pycache__/
+*.pyc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python: 3.5
 install: pip install -r requirements.txt
-script: pelican content -s pelicanconf.py -t theme
+script: pelican --fatal errors content -s pelicanconf.py -t theme

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Komitywa & contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 komitywa.org - statically generated site of Komitywa
+
+To build site:
+```shell
+pelican content
+```
+
+To review created site go to output directory and:
+```shell
+python -m pelican.server
+```

--- a/content/myfirstreview.md
+++ b/content/myfirstreview.md
@@ -1,5 +1,5 @@
 Title: My First Review
-Date: 2016-22-02 20:05
+Date: 2016-02-22 20:05
 Category: Review
 
 Following is a review of my favorite mechanical keyboard.

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -1,1 +1,0 @@
-#Pelicanconf.py

--- a/publishconf.py
+++ b/publishconf.py
@@ -1,1 +1,0 @@
-#Publishconf.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pelican
+-e git+https://github.com/getpelican/pelican#egg=pelican
 Markdown
-fabric


### PR DESCRIPTION
- readme updated to show, how to build this site,
- license added (MIT License),
- Travis fixes (current release of Pelican doesn't provide a way to reaturn nonzero exit code when generating pages failed, but it is already in tip of master branch),
